### PR TITLE
[FIX] delete PDF invoice attachment on invoice back to draft

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -173,20 +173,6 @@ class Py3oReport(models.TransientModel):
         return context_instance.localcontext
 
     @api.model
-    def _get_report_from_name(self, report_name):
-        """Get the first record of ir.actions.report.xml having the
-        ``report_name`` as value for the field report_name.
-        """
-        res = super(Py3oReport, self)._get_report_from_name(report_name)
-        if res:
-            return res
-        # maybe a py3o reprot
-        report_obj = self.env['ir.actions.report.xml']
-        return report_obj.search(
-            [('report_type', '=', 'py3o'),
-             ('report_name', '=', report_name)])
-
-    @api.model
     def _postprocess_report(self, report_path, res_id, save_in_attachment):
         if save_in_attachment.get(res_id):
             with open(report_path, 'rb') as pdfreport:
@@ -340,3 +326,22 @@ class Py3oReport(models.TransientModel):
             res = fd.read()
         self._cleanup_tempfiles(set(reports_path))
         return res, filetype
+
+
+class Report(models.Model):
+    _inherit = "report"
+
+    @api.model
+    def _get_report_from_name(self, report_name):
+        """Get the first record of ir.actions.report.xml having the
+        ``report_name`` as value for the field report_name.
+        """
+        res = super(Report, self)._get_report_from_name(report_name)
+        if res:
+            return res
+        # maybe a py3o report
+        report_obj = self.env['ir.actions.report.xml']
+        context = self.env['res.users'].context_get()
+        return report_obj.with_context(context).search(
+            [('report_type', '=', 'py3o'),
+             ('report_name', '=', report_name)], limit=1)


### PR DESCRIPTION
I made this change because I figured out that the native feature "auto delete PDF invoice attachment upon reset to draft of the invoice" was not working with report_py3o PDF invoices. With this change, it works.